### PR TITLE
task: allowing Procfile with comments

### DIFF
--- a/dev/internal/rebuilder/procfile.go
+++ b/dev/internal/rebuilder/procfile.go
@@ -30,6 +30,15 @@ func readProcfile(path string) ([]entry, error) {
 			continue
 		}
 
+		for i := range parts {
+			parts[i] = strings.TrimSpace(parts[i])
+		}
+
+		// Skipping comments in Procfile
+		if strings.HasPrefix(parts[0], "#") {
+			continue
+		}
+
 		exists := slices.ContainsFunc(entries, func(e entry) bool {
 			return e.Name == parts[0]
 		})
@@ -38,11 +47,14 @@ func readProcfile(path string) ([]entry, error) {
 			continue
 		}
 
-		entries = append(entries, entry{
+		e := entry{
 			ID:      len(entries),
 			Name:    strings.TrimSpace(parts[0]),
 			Command: strings.TrimSpace(parts[1]),
-		})
+		}
+
+		entries = append(entries, e)
+		maxServiceNameLen = max(maxServiceNameLen, len(e.Name))
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/dev/internal/rebuilder/rebuilder.go
+++ b/dev/internal/rebuilder/rebuilder.go
@@ -14,8 +14,6 @@ func Serve(ctx context.Context) error {
 		return err
 	}
 
-	fmt.Println("[kit] Starting app")
-
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 

--- a/dev/internal/rebuilder/rebuilder.go
+++ b/dev/internal/rebuilder/rebuilder.go
@@ -2,7 +2,6 @@ package rebuilder
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -33,8 +32,6 @@ func Serve(ctx context.Context) error {
 	for range entries {
 		<-exitCh
 	}
-
-	fmt.Println("[kit] Shutting down...")
 
 	return nil
 }

--- a/dev/internal/rebuilder/rebuilder_test.go
+++ b/dev/internal/rebuilder/rebuilder_test.go
@@ -347,4 +347,90 @@ func TestServe(t *testing.T) {
 			t.Errorf("Expected an error, got nil")
 		}
 	})
+
+	t.Run("Validate log trailing spaces", func(t *testing.T) {
+		r, w, _ := os.Pipe()
+
+		stdOut := os.Stdout
+		stdErr := os.Stderr
+
+		os.Stdout = w
+		os.Stderr = w
+		t.Cleanup(func() {
+			os.Stdout = stdOut
+			os.Stderr = stdErr
+		})
+
+		procfile()
+		os.WriteFile("Procfile", []byte("123: echo '123'\n1234: echo '1234'\n12345: echo '12345'"), 0o644)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		if err := rebuilder.Serve(ctx); err != nil {
+			t.Errorf("Expected nil, got '%v'", err)
+		}
+
+		w.Close()
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+
+		if !strings.Contains(buf.String(), "123   |") {
+			t.Errorf("Expected '123   |' to be in the output, got '%v'", buf.String())
+		}
+
+		if !strings.Contains(buf.String(), "1234  |") {
+			t.Errorf("Expected '1234  |' to be in the output, got '%v'", buf.String())
+		}
+
+		if !strings.Contains(buf.String(), "12345 |") {
+			t.Errorf("Expected '12345 |' to be in the output, got '%v'", buf.String())
+		}
+	})
+
+	t.Run("Read Procfile with comments", func(t *testing.T) {
+		r, w, _ := os.Pipe()
+
+		stdOut := os.Stdout
+		stdErr := os.Stderr
+
+		os.Stdout = w
+		os.Stderr = w
+		t.Cleanup(func() {
+			os.Stdout = stdOut
+			os.Stderr = stdErr
+		})
+
+		procfile()
+
+		content := `
+		# This is my awesome comment for my first command.
+
+		# This command 'hello' will print a friendly 'Hello, world!'
+		hello: echo 'Hello, world!'
+
+		# This command is commented because won't be used
+		# bye: echo 'Bye!'`
+
+		os.WriteFile("Procfile", []byte(content), 0o644)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		if err := rebuilder.Serve(ctx); err != nil {
+			t.Errorf("Expected nil, got '%v'", err)
+		}
+
+		w.Close()
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+
+		if strings.Count(buf.String(), "hello |") != 3 {
+			t.Errorf("Expected 'hello |' to be in the output, got '%v'", buf.String())
+		}
+
+		if strings.Contains(buf.String(), "bye") {
+			t.Errorf("Expected 'bye' to be commented, got '%v'", buf.String())
+		}
+	})
 }

--- a/dev/internal/rebuilder/rebuilder_test.go
+++ b/dev/internal/rebuilder/rebuilder_test.go
@@ -71,12 +71,8 @@ func TestServe(t *testing.T) {
 		var buf bytes.Buffer
 		io.Copy(&buf, r)
 
-		if !strings.Contains(buf.String(), "[kit] Starting app") {
-			t.Errorf("Expected '[kit] Starting app' to be in the output, got '%v'", buf.String())
-		}
-
-		if !strings.Contains(buf.String(), "[kit] Shutting down...") {
-			t.Errorf("Expected '[kit] Shutting down...' to be in the output, got '%v'", buf.String())
+		if !strings.Contains(buf.String(), "web |") {
+			t.Errorf("Expected 'web |' to be in the output, got '%v'", buf.String())
 		}
 	})
 
@@ -118,16 +114,12 @@ func TestServe(t *testing.T) {
 		var buf bytes.Buffer
 		io.Copy(&buf, r)
 
-		if !strings.Contains(buf.String(), "[kit] Starting app") {
-			t.Errorf("Expected '[kit] Starting app' to be in the output, got '%v'", buf.String())
+		if !strings.Contains(buf.String(), "web |") {
+			t.Errorf("Expected 'web |' to be in the output, got '%v'", buf.String())
 		}
 
 		if !strings.Contains(buf.String(), "Restarted...") {
 			t.Errorf("Expected 'Restarted...' to be in the output, got '%v'", buf.String())
-		}
-
-		if !strings.Contains(buf.String(), "[kit] Shutting down...") {
-			t.Errorf("Expected '[kit] Shutting down...' to be in the output, got '%v'", buf.String())
 		}
 	})
 

--- a/dev/internal/rebuilder/writer.go
+++ b/dev/internal/rebuilder/writer.go
@@ -10,7 +10,9 @@ import (
 	"time"
 )
 
-var maxServiceNameLen = 4
+// MaxServiceNameLen will receive the max length of the command name.
+// This will be used to calculate the trailing spaces.
+var maxServiceNameLen int
 
 var colors = []string{
 	"\033[92m", // Green
@@ -38,7 +40,7 @@ func (cw *customWriter) Write(p []byte) (int, error) {
 	defer cw.mu.Unlock()
 
 	timestamp := time.Now().Format(time.DateTime)
-	trailingSpaces := strings.Repeat(" ", max(maxServiceNameLen-len(cw.prefix), 0))
+	trailingSpaces := strings.Repeat(" ", max(maxServiceNameLen-len(cw.prefix), 0)+1)
 
 	scanner := bufio.NewScanner(bytes.NewReader(p))
 	for scanner.Scan() {
@@ -54,6 +56,10 @@ func (cw *customWriter) Write(p []byte) (int, error) {
 		if _, err := cw.writer.Write([]byte(line)); err != nil {
 			return 0, err
 		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return 0, err
 	}
 
 	return len(p), nil


### PR DESCRIPTION
This PR allows reading a Procfile ignoring comments

```plain

# This is my comment for the app command....
app: go run ./cmd.app

# This command have been commented because bla bla bla...
# hello: echo 'Hello world'
```
dev tool will execute only the available commands:

```bash
[date] app | ...
```